### PR TITLE
Add hidden developer toggle for XP boost button

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,23 @@
     .xp-button{ background:var(--color-secondary); color:#111; border:0; border-radius:4px; padding:8px 12px; font-size:14px; font-weight:600; cursor:pointer; }
     .xp-button:hover{ filter:brightness(1.05); }
     .xp-button:active{ transform: translateY(1px); }
+    .dev-toggle-btn{
+      background:transparent;
+      color:#fff;
+      border:1px dashed rgba(255,255,255,0.6);
+      border-radius:4px;
+      padding:6px 10px;
+      font-size:12px;
+      font-weight:600;
+      letter-spacing:0.03em;
+      cursor:pointer;
+    }
+    .dev-toggle-btn:focus-visible{ outline-color: var(--color-accent); }
+    body.dark-mode .dev-toggle-btn{
+      color: var(--color-text-dark);
+      border-color: rgba(255,255,255,0.35);
+      background: rgba(0,0,0,0.25);
+    }
     .toggle-theme-btn{ background:transparent; color:#fff; border:2px solid #fff; border-radius:6px; padding:6px 10px; cursor:pointer; }
     .toggle-theme-btn:hover{ background:#fff; color:var(--color-primary); }
     body.dark-mode .toggle-theme-btn{ color:#fff; border-color:#fff; }
@@ -343,7 +360,8 @@
           </div>
         </div>
 
-        <button class="xp-button hit-target" id="xpBtn" type="button" aria-describedby="xpLive">+10 XP</button>
+        <button class="dev-toggle-btn hit-target" id="devXpToggle" type="button" hidden aria-pressed="false" aria-label="Alternar botão de XP">XP Boost: Desligado</button>
+        <button class="xp-button hit-target" id="xpBtn" type="button" aria-describedby="xpLive" hidden>+10 XP</button>
         <button class="toggle-theme-btn hit-target" id="themeToggle" type="button" aria-label="Alternar tema">
           <i class="fas fa-adjust" aria-hidden="true"></i>
         </button>
@@ -648,6 +666,8 @@
   const K_THEME = 'lmup_theme';
   const K_FAVS  = 'lmup_favs_v1';
   const K_FAV_ONLY = 'lmup_fav_only';
+  const K_DEV_TOOLS = 'lmup_devtools';
+  const K_DEV_XP = 'lmup_dev_xp';
 
   // helpers primeiro
   const safeGet = (k, fb=null)=>{ try{ const v=localStorage.getItem(k); return v??fb; }catch{ return fb; } };
@@ -674,6 +694,7 @@
   const closeModalBtn= document.getElementById('closeModalBtn');
   const newLevelValue= document.getElementById('newLevelValue');
   const searchStatus = document.getElementById('searchStatus');
+  const devXpToggle  = document.getElementById('devXpToggle');
 
   function getDisplayName(){
     return (safeGet(K_NAME, '') || '').trim();
@@ -749,6 +770,54 @@
     progressBar.style.width = pct + '%';
   }
   let { level, xp } = loadProgress(); updateProgressUI(level, xp);
+
+  /* Dev tools: XP boost */
+  let devToolsOn = safeGet(K_DEV_TOOLS, '0') === '1';
+  let xpBoostOn = devToolsOn && safeGet(K_DEV_XP, '0') === '1';
+  function syncDevXpUI(){
+    document.body.classList.toggle('dev-tools', devToolsOn);
+    const boostActive = devToolsOn && xpBoostOn;
+    if(devXpToggle){
+      devXpToggle.hidden = !devToolsOn;
+      devXpToggle.setAttribute('aria-pressed', String(boostActive));
+      devXpToggle.textContent = boostActive ? 'XP Boost: Ligado' : 'XP Boost: Desligado';
+      if(devToolsOn){ devXpToggle.removeAttribute('aria-hidden'); }
+      else{ devXpToggle.setAttribute('aria-hidden','true'); }
+    }
+    if(xpBtn){
+      xpBtn.hidden = !boostActive;
+      if(boostActive){ xpBtn.removeAttribute('aria-hidden'); }
+      else{ xpBtn.setAttribute('aria-hidden','true'); }
+    }
+  }
+  syncDevXpUI();
+  if(window?.console?.info){
+    console.info('Modo desenvolvedor: use Ctrl+Shift+D (ou ⌘+Shift+D) para alternar a visibilidade do botão de XP.');
+  }
+
+  function toggleDevTools(){
+    devToolsOn = !devToolsOn;
+    safeSet(K_DEV_TOOLS, devToolsOn ? '1' : '0');
+    if(!devToolsOn){
+      xpBoostOn = false;
+      safeSet(K_DEV_XP, '0');
+    }
+    syncDevXpUI();
+  }
+
+  devXpToggle?.addEventListener('click', ()=>{
+    if(!devToolsOn) return;
+    xpBoostOn = !xpBoostOn;
+    safeSet(K_DEV_XP, (xpBoostOn && devToolsOn) ? '1' : '0');
+    syncDevXpUI();
+  });
+
+  document.addEventListener('keydown', (e)=>{
+    if(!(e.key && (e.ctrlKey || e.metaKey) && e.shiftKey)) return;
+    if(e.key.toLowerCase() !== 'd') return;
+    e.preventDefault();
+    toggleDevTools();
+  });
 
   const announce = msg => { if (msg) { document.getElementById('xpLive').textContent = msg; } };
 

--- a/index.html
+++ b/index.html
@@ -792,7 +792,7 @@
   }
   syncDevXpUI();
   if(window?.console?.info){
-    console.info('Modo desenvolvedor: use Ctrl+Shift+D (ou ⌘+Shift+D) para alternar a visibilidade do botão de XP.');
+    console.info('Modo desenvolvedor: use F8 para alternar a visibilidade do botão de XP.');
   }
 
   function toggleDevTools(){
@@ -813,8 +813,7 @@
   });
 
   document.addEventListener('keydown', (e)=>{
-    if(!(e.key && (e.ctrlKey || e.metaKey) && e.shiftKey)) return;
-    if(e.key.toLowerCase() !== 'd') return;
+    if(e.key !== 'F8') return;
     e.preventDefault();
     toggleDevTools();
   });


### PR DESCRIPTION
## Summary
- hide the XP boost control by default and expose a developer-only toggle in the top bar
- persist developer mode and XP boost state in localStorage with a keyboard shortcut to enable it
- add styling and a console hint for the developer shortcut

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dac69677188322ae9e464d741f67fc