### PR TITLE
Improve dark mode card borders

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
       --color-card-bg-dark: hsl(0 0% 17%);
       --color-sidebar-bg-dark: hsl(0 0% 16%);
       --color-border-dark: hsl(0 0% 27%);
+      --color-border-dark-contrast: hsl(0 0% 88%);
       --color-topbar-bg-dark: hsl(198 63% 12%);
       --focus-ring: hsl(265 100% 60%);
       --tap-min: 24px;
@@ -91,6 +92,7 @@
         --color-card-bg-dark: oklch(28% 0.01 255);
         --color-sidebar-bg-dark: oklch(27% 0.01 255);
         --color-border-dark: oklch(40% 0.02 255);
+        --color-border-dark-contrast: oklch(88% 0.01 255);
         --color-topbar-bg-dark: oklch(28% 0.05 235);
         --focus-ring: oklch(54% 0.29 285);
         --color-gold: oklch(82% 0.17 85);
@@ -243,7 +245,7 @@
     body.dark-mode{ background:var(--color-bg-dark); color:var(--color-text-dark); }
     body.dark-mode .topbar{ background:var(--color-topbar-bg-dark); color:var(--color-text-dark); }
     body.dark-mode .sidebar{ background:var(--color-sidebar-bg-dark); border-right:1px solid var(--color-border-dark); }
-    body.dark-mode .subarea-card{ background:var(--color-card-bg-dark); border-color:var(--color-border-dark); color:var(--color-text-dark); }
+    body.dark-mode .subarea-card{ background:var(--color-card-bg-dark); border:1px solid var(--color-border-dark-contrast); color:var(--color-text-dark); }
     body.dark-mode .nav-section a{ color:var(--color-text-dark); }
     body.dark-mode .nav-section a:hover{ color:var(--color-accent); }
     body.dark-mode .subarea-mestre{ background:hsl(0 0% 26%); }

--- a/progresso.html
+++ b/progresso.html
@@ -52,6 +52,7 @@
       --card-dark: #1f1f1f;
       --border: #e5e7eb;
       --border-dark: #2c2c2c;
+      --border-dark-contrast: #e0e0e0;
       --accent: #8b5cf6;
       --secondary: #f6c453;
       --soft: #f3f4f6;
@@ -159,7 +160,7 @@
 
     /* Dark mode básico quando aberto direto (MPA) */
     .dark-mode{ background:var(--bg-dark); color:var(--text-dark); }
-    .dark-mode .card, .dark-mode .subject-tile, .dark-mode .quest{ background:var(--card-dark); border-color:var(--border-dark); }
+    .dark-mode .card, .dark-mode .subject-tile, .dark-mode .quest{ background:var(--card-dark); border:1px solid var(--border-dark-contrast); }
 
     /* Link do logo no progresso */
     .brand-link{
@@ -199,7 +200,7 @@
     /* botões no dark: deixam de ser clarinhos */
     body.dark-mode .btn{
       background:#262626;
-      border-color: var(--border-dark);
+      border: 1px solid var(--border-dark-contrast);
       color: var(--text-dark);
     }
     body.dark-mode .btn:hover{ filter:brightness(1.05); }
@@ -235,7 +236,7 @@
     body.dark-mode .widget {
       background: var(--card-dark);
       color: var(--text-dark);
-      border-color: var(--border-dark);
+      border: 1px solid var(--border-dark-contrast);
     }
 
     /* Pílulas / badges / tags (os “Recente”, “Foco”, etc) */
@@ -249,16 +250,16 @@
     body.dark-mode [class*="tag"]{
       background: hsl(0 0% 22%);
       color: var(--text-dark);
-      border: 1px solid var(--border-dark);
+      border: 1px solid var(--border-dark-contrast);
     }
     /* Tabelas (Histórico) */
     body.dark-mode table { color: var(--text-dark); }
     body.dark-mode th {
       background: var(--card-dark);
       color: var(--text-dark);
-      border-bottom: 1px solid var(--border-dark);
+      border-bottom: 1px solid var(--border-dark-contrast);
     }
-    body.dark-mode td { border-top: 1px solid var(--border-dark); }
+    body.dark-mode td { border-top: 1px solid var(--border-dark-contrast); }
 
     /* Legendas/pequenos textos dentro de widgets escuros */
     body.dark-mode .legend,


### PR DESCRIPTION
## Summary
- add a dedicated light border token for dark mode on the home page and apply it to subarea cards
- brighten dark mode borders across progress cards, badges, and tables using the new contrast variable for clearer separation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dadd3d25a08322a7fcf9730afa73b8