### PR TITLE
Fix banner button positioning and area badge order on profile

### DIFF
--- a/perfil.html
+++ b/perfil.html
@@ -201,9 +201,9 @@
     }
     .banner-btn{
       position:absolute;
-      bottom:16px;
+      top:16px;
       right:16px;
-      top:auto;
+      bottom:auto;
       left:auto;
       border:1px solid rgba(11,48,66,0.28);
       background:linear-gradient(135deg, rgba(255,255,255,0.97), rgba(221,232,255,0.9));
@@ -403,9 +403,9 @@
     .dark-mode .empty-state{ background:rgba(29,33,37,0.8); border-color:var(--border-dark); }
     .dark-mode .banner{ border-color:var(--border-dark-contrast); }
     .dark-mode .banner-btn{
-      bottom:16px;
+      top:16px;
       right:16px;
-      top:auto;
+      bottom:auto;
       left:auto;
       border-color:rgba(255,255,255,0.24);
       background:rgba(20,26,32,0.68);
@@ -453,8 +453,8 @@
                 <strong id="profileTotalBadge">0</strong>
               </li>
               <li class="pill">
-                <span class="badge-label">Áreas</span>
                 <strong id="profileAreasBadge">0</strong>
+                <span class="badge-label">Áreas</span>
               </li>
             </ul>
           </div>

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,8 @@
 // sw.js
-// SW v1.0.10 — precache do shell + stale-while-revalidate para assets (mesmo-origin)
+// SW v1.0.11 — precache do shell + stale-while-revalidate para assets (mesmo-origin)
 
 const CACHE_PREFIX = 'lmu-cache';
-const VERSION = 'v1.0.10';
+const VERSION = 'v1.0.11';
 const PRECACHE = `${CACHE_PREFIX}-precache-${VERSION}`;
 const RUNTIME  = `${CACHE_PREFIX}-runtime-${VERSION}`;
 


### PR DESCRIPTION
## Summary
- standardize the profile banner edit button placement and ensure badges follow the expected order
- keep the profile style tokens consistent for both color schemes and maintain existing banner validation logic
- bump the service worker cache version to push the canonical profile page to clients

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db31681e588322aa0c6e62aa76e2c2