### PR TITLE
Fix profile hero section aria-labelledby reference

### DIFF
--- a/perfil.html
+++ b/perfil.html
@@ -425,7 +425,7 @@
   <a class="skip-link" href="#conteudo">Ir para o conteúdo principal</a>
   <main id="conteudo">
     <div class="wrap">
-      <section class="card profile-hero" aria-labelledby="profileTitle">
+      <section class="card profile-hero" aria-labelledby="profileNameDisplay">
         <div class="banner" role="img" aria-label="Banner personalizado do perfil">
           <input id="bannerFileInput" class="sr-only" type="file" accept="image/png, image/jpeg, image/webp">
           <button id="bannerEditBtn" class="btn banner-btn" type="button">Editar banner</button>


### PR DESCRIPTION
## Summary
- point the profile hero section's aria-labelledby attribute to the existing profile name display element so the reference is valid
- ensure the referenced id stays in sync with the dynamic profile name updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db3b869d1c8322953332a4daece9d2