### PR TITLE
Ajusta layout do banner de perfil

### DIFF
--- a/progresso.html
+++ b/progresso.html
@@ -413,9 +413,12 @@
     <section class="card section" aria-labelledby="perfil-h">
       <div class="profile-hero">
         <div class="avatar" id="avatarBox" aria-label="Avatar do usuário"><span id="avatarInitial">?</span></div>
-        <div class="profile-info">
-          <div class="profile-name"><span id="profileName">Visitante</span></div>
-          <span class="tag" id="quickStats"><i class="fa-regular fa-star" aria-hidden="true"></i> <span id="statLevel">Nível 1</span></span>
+        <div class="profile-banner">
+          <div class="profile-info">
+            <div class="profile-name"><span id="profileName">Visitante</span></div>
+            <span class="tag" id="quickStats"><i class="fa-regular fa-star" aria-hidden="true"></i> <span id="statLevel">Nível 1</span></span>
+          </div>
+          <button class="btn" id="editBannerBtn" type="button"><i class="fa-regular fa-image" aria-hidden="true"></i> Editar banner</button>
         </div>
         <div class="profile-actions">
           <label class="btn" for="avatarInput" role="button" tabindex="0"><i class="fa-regular fa-image" aria-hidden="true"></i> Editar avatar</label>


### PR DESCRIPTION
## Summary
- agrupa nome e estatísticas do perfil em um contêiner `profile-banner`
- adiciona botão de ação para edição do banner dentro do novo agrupamento

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db3facce048322ba98cd5e94e1c9e0