### PR TITLE
Alinha badges de progresso à direita no perfil

### DIFF
--- a/perfil.html
+++ b/perfil.html
@@ -221,12 +221,13 @@
 
     .profile-core{
       display:flex;
-      flex-wrap:wrap;
+      align-items:center;
       gap:18px;
-      padding:0 24px 24px;
-      margin-top:-52px;
+      padding:0 0 24px 24px;
+      margin-top:0;
       position:relative;
       z-index:1;
+      flex-wrap:nowrap;
     }
     .avatar{
       width:108px;
@@ -243,7 +244,7 @@
       overflow:hidden;
     }
     .avatar img{ width:100%; height:100%; object-fit:cover; display:block; }
-    .profile-info{ flex:1; min-width:220px; display:flex; flex-direction:column; gap:8px; }
+    .profile-info{ flex:1; min-width:0; display:flex; flex-direction:column; gap:8px; }
     .profile-name{ font-size:26px; font-weight:800; color: var(--text); }
     .pill{
       display:inline-flex;
@@ -257,7 +258,7 @@
       border:1px solid rgba(139,92,246,0.32);
       box-shadow:0 2px 6px rgba(15,23,42,0.08);
     }
-    .profile-badges{ list-style:none; padding:0; margin:0; display:flex; flex-wrap:wrap; gap:12px; }
+    .profile-badges{ list-style:none; padding:0; margin:0; display:flex; flex-wrap:wrap; gap:12px; margin-left:auto; justify-content:flex-end; }
     .profile-badges li{ display:flex; align-items:center; gap:6px; }
     .profile-badges strong{ font-size:18px; }
 
@@ -410,23 +411,17 @@
 
     @media (max-width: 980px){
       .grid{ grid-template-columns: 1fr; }
-      .profile-core{ margin-top:-40px; padding-bottom:20px; }
+      .profile-core{ margin-top:0; padding:0 16px 20px; }
       .avatar{ width:92px; height:92px; border-radius:20px; }
     }
+    @media (max-width: 720px){
+      .profile-core{ flex-direction:column; align-items:flex-start; padding:0 24px 24px; gap:16px; }
+      .profile-badges{ margin-left:0; justify-content:flex-start; width:100%; }
+    }
     @media (max-width: 560px){
-      .profile-core{ flex-direction:column; align-items:flex-start; }
       .profile-badges{ gap:8px; }
       .stats-list{ grid-template-columns:1fr; }
       .banner{ height:140px; }
-    }
-    @media (min-width: 720px){
-      .profile-info{
-        flex-direction: row;
-        align-items: center;
-      }
-      .profile-badges{
-        margin-left: auto;
-      }
     }
   </style>
 </head>
@@ -446,21 +441,21 @@
           </div>
           <div class="profile-info">
             <div class="profile-name" id="profileNameDisplay">Visitante</div>
-            <ul class="profile-badges" aria-label="Resumo rápido do perfil">
-              <li class="pill">
-                <strong id="profileLevelBadge">1</strong>
-                <span class="badge-label">Nível</span>
-              </li>
-              <li class="pill">
-                <strong id="profileTotalBadge">0</strong>
-                <span class="badge-label">XP total</span>
-              </li>
-              <li class="pill">
-                <strong id="profileAreasBadge">0</strong>
-                <span class="badge-label">Áreas</span>
-              </li>
-            </ul>
           </div>
+          <ul class="profile-badges" aria-label="Resumo rápido do perfil">
+            <li class="pill">
+              <strong id="profileLevelBadge">1</strong>
+              <span class="badge-label">Nível</span>
+            </li>
+            <li class="pill">
+              <strong id="profileTotalBadge">0</strong>
+              <span class="badge-label">XP total</span>
+            </li>
+            <li class="pill">
+              <strong id="profileAreasBadge">0</strong>
+              <span class="badge-label">Áreas</span>
+            </li>
+          </ul>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- reestrutura a seção principal do perfil para que os badges fiquem alinhados à direita
- ajusta o layout flex da área de perfil removendo margens negativas e garantindo espaçamento correto
- atualiza regras responsivas para manter o cabeçalho do perfil consistente em telas menores

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db482a912483228d9f240d9c138961