### PR TITLE
Adjust profile badges layout for desktop view

### DIFF
--- a/perfil.html
+++ b/perfil.html
@@ -258,7 +258,7 @@
       border:1px solid rgba(139,92,246,0.32);
       box-shadow:0 2px 6px rgba(15,23,42,0.08);
     }
-    .profile-badges{ list-style:none; padding:0; margin:0; display:flex; flex-wrap:wrap; gap:12px; margin-left:auto; justify-content:flex-end; }
+    .profile-badges{ list-style:none; padding:0; margin:0; display:flex; flex-wrap:wrap; gap:12px; justify-content:flex-start; }
     .profile-badges li{ display:flex; align-items:center; gap:6px; }
     .profile-badges strong{ font-size:18px; }
 
@@ -423,17 +423,16 @@
       .stats-list{ grid-template-columns:1fr; }
       .banner{ height:140px; }
     }
-    /* Desktop: badges ao lado do nome e “seguem” o comprimento do nome */
     @media (min-width: 720px){
       .profile-info{
-        flex-direction: row;   /* sai da coluna */
-        align-items: baseline; /* alinha pelo baseline do texto do nome */
-        flex-wrap: wrap;       /* se o nome for longo, badges quebram abaixo do nome */
-        gap: 6px 12px;         /* espaço entre nome↔badges e entre linhas */
+        flex-direction: row;
+        align-items: baseline;
+        flex-wrap: wrap;
+        gap: 6px 12px;
       }
       .profile-name{ margin-right: 8px; }
       .profile-badges{
-        margin-left: 0;        /* cancela o “empurrão” para a direita */
+        margin-left: 0;
         justify-content: flex-start;
       }
     }
@@ -455,21 +454,21 @@
           </div>
           <div class="profile-info">
             <div class="profile-name" id="profileNameDisplay">Visitante</div>
+            <ul class="profile-badges" aria-label="Resumo rápido do perfil">
+              <li class="pill">
+                <strong id="profileLevelBadge">1</strong>
+                <span class="badge-label">Nível</span>
+              </li>
+              <li class="pill">
+                <strong id="profileTotalBadge">0</strong>
+                <span class="badge-label">XP total</span>
+              </li>
+              <li class="pill">
+                <strong id="profileAreasBadge">0</strong>
+                <span class="badge-label">Áreas</span>
+              </li>
+            </ul>
           </div>
-          <ul class="profile-badges" aria-label="Resumo rápido do perfil">
-            <li class="pill">
-              <strong id="profileLevelBadge">1</strong>
-              <span class="badge-label">Nível</span>
-            </li>
-            <li class="pill">
-              <strong id="profileTotalBadge">0</strong>
-              <span class="badge-label">XP total</span>
-            </li>
-            <li class="pill">
-              <strong id="profileAreasBadge">0</strong>
-              <span class="badge-label">Áreas</span>
-            </li>
-          </ul>
         </div>
       </section>
 

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,8 @@
 // sw.js
-// SW v1.0.12 — precache do shell + stale-while-revalidate para assets (mesmo-origin)
+// SW v1.0.13 — precache do shell + stale-while-revalidate para assets (mesmo-origin)
 
 const CACHE_PREFIX = 'lmu-cache';
-const VERSION = 'v1.0.12';
+const VERSION = 'v1.0.13';
 const PRECACHE = `${CACHE_PREFIX}-precache-${VERSION}`;
 const RUNTIME  = `${CACHE_PREFIX}-runtime-${VERSION}`;
 


### PR DESCRIPTION
## Summary
- nest the profile badges list inside the profile info container to keep it adjacent to the user name
- update the profile layout styles so desktop view wraps badges next to the name and defaults to left alignment
- bump the service worker cache version to refresh cached profile assets

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68db4da0471c8322b0b72d19108e47dc