### PR TITLE
Corrige fluxo do editor inline no perfil

### DIFF
--- a/perfil.html
+++ b/perfil.html
@@ -535,6 +535,30 @@
       box-shadow:var(--shadow-dark);
     }
     .dark-mode .profile-inline-name-editor::placeholder{ color:rgba(226,232,240,0.64); }
+
+    /* 1) No modo de edição, esconda o nome do fluxo */
+    .profile-info.is-inline-editing #profileNameDisplay{
+      display: none;           /* em vez de só opacity:0 */
+    }
+
+    /* 2) Faça o editor participar do fluxo para empurrar as badges */
+    .profile-info.is-inline-editing .profile-inline-name-editor{
+      position: static;        /* sai do absolute */
+      display: inline-block;   /* ocupa só o necessário */
+      width: auto;
+      max-width: 100%;
+      top: auto; left: auto;   /* garantias caso tenham ficado da regra anterior */
+    }
+
+    /* (opcional) Deixe a linha mais estável durante a edição */
+    @media (min-width: 720px){
+      .profile-info{           /* já é Flex + wrap; só reforçando */
+        flex-direction: row;
+        align-items: baseline;
+        flex-wrap: wrap;
+        gap: 6px 12px;
+      }
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- oculta o nome exibido ao entrar no modo de edição inline para removê-lo do fluxo
- reposiciona o input de edição para participar do fluxo normal do layout
- reforça o comportamento flex em telas largas para manter alinhamento durante a edição

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db5dd1890083228cf3812c585ff3ed