### PR TITLE
Adjust profile badge layout and banner button styling

### DIFF
--- a/perfil.html
+++ b/perfil.html
@@ -575,7 +575,7 @@
           <button id="quickNameBtn" class="btn hero-btn" type="button" aria-controls="profileNameInlineInput">Alterar nome</button>
           <button id="quickAvatarBtn" class="btn hero-btn" type="button" aria-controls="profileAvatarInput">Alterar avatar</button>
 
-          <button id="bannerEditBtn" class="btn banner-btn" type="button">Editar banner</button>
+          <button id="bannerEditBtn" class="btn hero-btn" type="button">Alterar banner</button>
         </div>
         <div class="profile-core">
           <div class="avatar" id="profileAvatar" aria-hidden="true">
@@ -592,8 +592,8 @@
                    placeholder="Digite seu nome exibido">
             <ul class="profile-badges" aria-label="Resumo rápido do perfil">
               <li class="pill">
-                <strong id="profileLevelBadge">1</strong>
                 <span class="badge-label">Nível</span>
+                <strong id="profileLevelBadge">1</strong>
               </li>
               <li class="pill">
                 <strong id="profileTotalBadge">0</strong>

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,8 @@
 // sw.js
-// SW v1.0.13 — precache do shell + stale-while-revalidate para assets (mesmo-origin)
+// SW v1.0.14 — precache do shell + stale-while-revalidate para assets (mesmo-origin)
 
 const CACHE_PREFIX = 'lmu-cache';
-const VERSION = 'v1.0.13';
+const VERSION = 'v1.0.14';
 const PRECACHE = `${CACHE_PREFIX}-precache-${VERSION}`;
 const RUNTIME  = `${CACHE_PREFIX}-runtime-${VERSION}`;
 


### PR DESCRIPTION
## Summary
- reorder the level badge markup to display the label before the value
- align the banner edit button styling and copy with other hero actions
- bump the service worker cache version to refresh cached assets

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db6359e1008322ae84fcdc4cfe4fe2