### PR TITLE
Refatorar tipografia para modo escuro

### DIFF
--- a/perfil.html
+++ b/perfil.html
@@ -245,7 +245,7 @@
     }
     .avatar img{ width:100%; height:100%; object-fit:cover; display:block; }
     .profile-info{ flex:1; min-width:0; display:flex; flex-direction:column; gap:8px; }
-    .profile-name{ font-size:26px; font-weight:800; color: var(--text); }
+    .profile-name{ font-size:26px; font-weight:800; color: var(--text-strong); }
     .pill{
       display:inline-flex;
       align-items:center;
@@ -270,7 +270,7 @@
       background:rgba(139,92,246,0.05);
     }
     .stats-list h3{ margin:0 0 4px; font-size:16px; }
-    .stats-list p{ margin:0; color:var(--text-subtle); font-size:14px; }
+    .stats-list p{ margin:0; color:var(--text-muted); font-size:14px; }
 
     .activity-list{ list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:12px; }
     .activity-item{
@@ -283,8 +283,8 @@
     }
     .activity-header{ display:flex; justify-content:space-between; gap:10px; font-weight:700; }
     .activity-header span{ display:inline-flex; align-items:center; gap:6px; }
-    .activity-note{ color:var(--text-subtle); font-size:14px; }
-    .activity-meta{ font-size:13px; color:var(--text-subtle); display:flex; gap:10px; flex-wrap:wrap; }
+    .activity-note{ color:var(--text-muted); font-size:14px; }
+    .activity-meta{ font-size:13px; color:var(--text-muted); display:flex; gap:10px; flex-wrap:wrap; }
 
     .achievements-grid{ display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:12px; }
     .achievement{
@@ -299,7 +299,7 @@
     }
     .achievement i{ font-size:20px; }
     .achievement strong{ font-size:16px; }
-    .achievement p{ margin:0; font-size:13px; color:var(--text-subtle); }
+    .achievement p{ margin:0; font-size:13px; color:var(--text-muted); }
     .achievement.unlocked{
       border-style:solid;
       border-color:var(--accent);
@@ -328,7 +328,7 @@
       place-items:center;
       font-weight:700;
     }
-    .friend-meta{ font-size:13px; color:var(--text-subtle); }
+    .friend-meta{ font-size:13px; color:var(--text-muted); }
 
     .settings-card form{ display:flex; flex-direction:column; gap:14px; }
     .settings-card fieldset{ border:0; padding:0; margin:0; display:flex; flex-direction:column; gap:8px; }
@@ -361,8 +361,10 @@
     .btn:hover,
     .btn-primary:hover{ transform: translateY(-1px); box-shadow:0 6px 16px rgba(15,23,42,0.12); }
     .btn[aria-pressed="true"]{ background:var(--accent); color:#fff; border-color:var(--accent); }
-    .settings-help{ font-size:13px; color:var(--text-subtle); margin-top:-6px; }
+    .settings-help{ font-size:13px; color:var(--text-muted); margin-top:-6px; }
     .settings-actions{ display:flex; gap:8px; flex-wrap:wrap; }
+
+    small{ color:var(--text-muted); }
 
     .theme-toggle{ display:flex; justify-content:space-between; align-items:center; gap:12px; padding:14px; border:1px solid var(--border); border-radius:12px; background:rgba(139,92,246,0.06); }
     .theme-toggle strong{ font-size:15px; }
@@ -372,26 +374,26 @@
       border-radius:12px;
       padding:24px;
       text-align:center;
-      color:var(--text-subtle);
+      color:var(--text-muted);
       background:rgba(255,255,255,0.5);
     }
     .empty-state a{ color:var(--accent); font-weight:700; }
 
-    footer{ margin-top:32px; text-align:center; font-size:13px; color:var(--text-subtle); }
+    footer{ margin-top:32px; text-align:center; font-size:13px; color:var(--text-muted); }
 
-    .dark-mode{ background:var(--bg-dark); color:var(--text-dark); }
+    .dark-mode{ background:var(--bg-dark); color:var(--text); }
     .dark-mode .card,
     .dark-mode .activity-item,
     .dark-mode .friend-card,
     .dark-mode .theme-toggle,
     .dark-mode .stats-list li{ background:var(--card-dark); border:1px solid var(--border-dark-contrast); box-shadow: var(--shadow-dark); }
     .dark-mode .pill{ background:rgba(139,92,246,0.22); color:#f4ebff; border-color:rgba(139,92,246,0.5); box-shadow:0 4px 14px rgba(0,0,0,0.35); }
-    .dark-mode .profile-name{ color: var(--text-dark); }
+    .dark-mode .profile-name{ color: var(--text-strong); }
     .dark-mode .activity-note,
     .dark-mode .activity-meta,
     .dark-mode .friend-meta,
     .dark-mode .settings-help,
-    .dark-mode footer{ color:rgba(226,232,240,0.82); }
+    .dark-mode footer{ color:var(--text-muted); }
     .dark-mode .achievement{ background:rgba(29,33,37,0.9); border-color:var(--border-dark); }
     .dark-mode .achievement.unlocked{ background:rgba(139,92,246,0.22); }
     .dark-mode .input{ background:#161b1f; border-color:var(--border-dark); color:inherit; }
@@ -404,7 +406,7 @@
       right:16px;
       border-color:rgba(255,255,255,0.24);
       background:rgba(20,26,32,0.68);
-      color:var(--text-dark);
+      color:var(--text-strong);
       box-shadow:0 10px 24px rgba(0,0,0,0.35);
       text-shadow:none;
     }
@@ -520,7 +522,7 @@
       display:none;
       z-index:5;
     }
-    .profile-inline-name-editor::placeholder{ color:var(--text-subtle); font-weight:400; }
+    .profile-inline-name-editor::placeholder{ color:var(--text-muted); font-weight:400; }
     .profile-info.is-inline-editing #profileNameDisplay{
       opacity:0;
       pointer-events:none;
@@ -531,10 +533,10 @@
     .dark-mode .profile-inline-name-editor{
       background:var(--card-dark);
       border-color:var(--border-dark-contrast);
-      color:var(--text-dark);
+      color:var(--text);
       box-shadow:var(--shadow-dark);
     }
-    .dark-mode .profile-inline-name-editor::placeholder{ color:rgba(226,232,240,0.64); }
+    .dark-mode .profile-inline-name-editor::placeholder{ color:var(--text-muted); }
 
     /* 1) No modo de edição, esconda o nome do fluxo */
     .profile-info.is-inline-editing #profileNameDisplay{
@@ -557,6 +559,32 @@
         align-items: baseline;
         flex-wrap: wrap;
         gap: 6px 12px;
+      }
+    }
+
+    :root{
+      --text-strong: hsl(215 56% 18%);
+      --text:        hsl(215 28% 26%);
+      --text-muted:  hsl(217 17% 48%);
+      --text-subtle: var(--text-muted);
+      --text-dark:   var(--text-strong);
+    }
+
+    body{ color: var(--text); }
+
+    .dark-mode{
+      --text-strong: hsl(210 40% 96%);
+      --text:        hsl(210 28% 92%);
+      --text-muted:  hsl(215 20% 72%);
+      --text-subtle: var(--text-muted);
+      --text-dark:   var(--text-strong);
+    }
+
+    @media (prefers-color-scheme: dark){
+      body:not(.dark-mode){
+        --text-strong: hsl(210 40% 96%);
+        --text:        hsl(210 25% 92%);
+        --text-muted:  hsl(215 20% 72%);
       }
     }
   </style>

--- a/progresso.html
+++ b/progresso.html
@@ -96,7 +96,7 @@
       background:var(--card); border:1px solid var(--border); border-radius: var(--radius); padding:16px;
       box-shadow: var(--shadow);
     }
-    .card h3{ margin:0 0 12px; font-size:18px; }
+    .card h3{ margin:0 0 12px; font-size:18px; color: var(--text-strong); }
     .section{ margin-bottom:20px; }
     .tag{ display:inline-flex; align-items:center; gap:6px; padding:4px 8px; border-radius:999px; border:1px solid var(--border); background:var(--soft); font-size:12px; }
 
@@ -108,7 +108,7 @@
     }
     .avatar img{ width:100%; height:100%; object-fit:cover; display:block; }
     .profile-info{ display:flex; flex-wrap:wrap; align-items:center; gap:8px; }
-    .profile-name{ font-size:20px; font-weight:800; margin-right:6px; }
+    .profile-name{ font-size:20px; font-weight:800; margin-right:6px; color: var(--text-strong); }
     .profile-actions{ margin-left:auto; display:flex; gap:8px; }
     .btn{ border:1px solid var(--border); background:var(--soft); padding:6px 10px; border-radius:8px; }
     .btn:focus-visible{ outline:3px solid var(--focus); }
@@ -121,7 +121,7 @@
     }
     .subject-tile:hover{ transform: translateY(-2px); box-shadow: var(--shadow); }
     .subject-title{ font-weight:700; }
-    .subject-meta{ font-size:12px; color:#4b5563; display:flex; gap:8px; flex-wrap:wrap; }
+    .subject-meta{ font-size:12px; color:var(--text-muted); display:flex; gap:8px; flex-wrap:wrap; }
     .bar{ width:100%; height:8px; background:var(--soft); border-radius:999px; overflow:hidden; }
     .bar-fill{ height:100%; width:40%; background:var(--accent); }
 
@@ -138,7 +138,8 @@
     .heatmap{ line-height:0; }
     .hm-cell{ display:inline-block; width:12px; height:12px; margin:2px; border-radius:2px; background:#e5e7eb; }
     .hm-1{ background:#c7d2fe } .hm-2{ background:#93c5fd } .hm-3{ background:#60a5fa } .hm-4{ background:#3b82f6 }
-    .legend{ display:flex; align-items:center; gap:6px; font-size:12px; margin-top:8px; }
+    .legend{ display:flex; align-items:center; gap:6px; font-size:12px; margin-top:8px; color:var(--text-muted); }
+    small{ color:var(--text-muted); }
     .legend .hm-cell{ margin:0 2px; }
 
     /* Maestria */
@@ -159,7 +160,7 @@
     .menu{ display:flex; gap:8px; justify-content:flex-end; margin-top:.5rem; }
 
     /* Dark mode básico quando aberto direto (MPA) */
-    .dark-mode{ background:var(--bg-dark); color:var(--text-dark); }
+    .dark-mode{ background:var(--bg-dark); color:var(--text); }
     .dark-mode .card, .dark-mode .subject-tile, .dark-mode .quest{ background:var(--card-dark); border:1px solid var(--border-dark-contrast); }
 
     /* Link do logo no progresso */
@@ -195,13 +196,13 @@
     /* ==== Fixes de contraste no modo escuro ==== */
 
     /* meta das matérias (debaixo do título) */
-    body.dark-mode .subject-meta { color: var(--text-dark); }
+    body.dark-mode .subject-meta { color: var(--text-muted); }
 
     /* botões no dark: deixam de ser clarinhos */
     body.dark-mode .btn{
       background:#262626;
       border: 1px solid var(--border-dark-contrast);
-      color: var(--text-dark);
+      color: var(--text-strong);
     }
     body.dark-mode .btn:hover{ filter:brightness(1.05); }
 
@@ -221,11 +222,11 @@
     body.dark-mode,
     body.dark-mode .main,
     body.dark-mode .sidebar {
-      color: var(--text-dark);
+      color: var(--text);
     }
 
     /* Links no dark */
-    body.dark-mode a { color: var(--text-dark); }
+    body.dark-mode a { color: var(--text-strong); }
     body.dark-mode a:hover { color: var(--accent); }
 
     /* Cards/painéis genéricos */
@@ -235,7 +236,7 @@
     body.dark-mode .box,
     body.dark-mode .widget {
       background: var(--card-dark);
-      color: var(--text-dark);
+      color: var(--text);
       border: 1px solid var(--border-dark-contrast);
     }
 
@@ -249,14 +250,14 @@
     body.dark-mode [class*="chip"],
     body.dark-mode [class*="tag"]{
       background: hsl(0 0% 22%);
-      color: var(--text-dark);
+      color: var(--text-strong);
       border: 1px solid var(--border-dark-contrast);
     }
     /* Tabelas (Histórico) */
-    body.dark-mode table { color: var(--text-dark); }
+    body.dark-mode table { color: var(--text); }
     body.dark-mode th {
       background: var(--card-dark);
-      color: var(--text-dark);
+      color: var(--text-strong);
       border-bottom: 1px solid var(--border-dark-contrast);
     }
     body.dark-mode td { border-top: 1px solid var(--border-dark-contrast); }
@@ -265,7 +266,7 @@
     body.dark-mode .legend,
     body.dark-mode .legend small,
     body.dark-mode small {
-      color: var(--text-dark);
+      color: var(--text-muted);
     }
 
     /* Força correção quando algum elemento veio com color:#111/#000 inline */
@@ -274,7 +275,7 @@
     body.dark-mode [style*="color:#000"],
     body.dark-mode [style*="color: #000"],
     body.dark-mode .text-dark {
-      color: var(--text-dark) !important;
+      color: var(--text-strong) !important;
     }
 
     /* Botões de fundo claro DEVEM continuar com texto escuro p/ contraste */
@@ -380,6 +381,32 @@
       color: var(--color-gold) !important;
       --fa-primary-color: var(--color-gold) !important;
       --fa-secondary-color: var(--color-gold) !important;
+    }
+
+    :root{
+      --text-strong: hsl(215 56% 18%);
+      --text:        hsl(215 28% 24%);
+      --text-muted:  hsl(217 17% 48%);
+      --text-subtle: var(--text-muted);
+      --text-dark:   var(--text-strong);
+    }
+
+    body{ color: var(--text); }
+
+    .dark-mode{
+      --text-strong: hsl(210 40% 96%);
+      --text:        hsl(210 28% 92%);
+      --text-muted:  hsl(215 20% 72%);
+      --text-subtle: var(--text-muted);
+      --text-dark:   var(--text-strong);
+    }
+
+    @media (prefers-color-scheme: dark){
+      body:not(.dark-mode){
+        --text-strong: hsl(210 40% 96%);
+        --text:        hsl(210 25% 92%);
+        --text-muted:  hsl(215 20% 72%);
+      }
     }
   </style>
 </head>


### PR DESCRIPTION
## Resumo
- adiciona tokens de tipografia com variáveis CSS e aplica às tipografias principais nas páginas de perfil e progresso
- ajusta o modo escuro e a detecção de preferência do sistema para reaproveitar os novos tokens com contraste adequado
- alinha textos secundários, legendas e estados vazios para usar os novos valores `--text-muted`

## Testes
- Não aplicável (alterações apenas de estilo)


------
https://chatgpt.com/codex/tasks/task_e_68db6daa2c5483228b0987e94711325b