### PR TITLE
Refatora layout do perfil e força atualização do service worker

### DIFF
--- a/perfil.html
+++ b/perfil.html
@@ -216,6 +216,7 @@
       box-shadow:0 10px 22px rgba(15,23,42,0.22);
     }
 
+    /* Linha do perfil centralizada e fluida */
     .profile-core{
       display:flex;
       align-items:center;
@@ -535,16 +536,6 @@
       border-color:rgba(255,255,255,.18);
       text-shadow:none;
       box-shadow:0 10px 24px rgba(0,0,0,.35);
-    }
-
-    /* Linha do perfil centralizada e fluida */
-    .profile-core {
-      display: flex;
-      align-items: center;
-      gap: 16px;
-      padding: 0 24px 24px;
-      margin-top: 0;
-      flex-wrap: wrap;
     }
 
     /* Botões ao lado do nome (participam do fluxo) */

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,8 @@
 // sw.js
-// SW v1.0.19 — precache do shell + stale-while-revalidate para assets (mesmo-origin)
+// SW v1.0.20 — precache do shell + stale-while-revalidate para assets (mesmo-origin)
 
 const CACHE_PREFIX = 'lmu-cache';
-const VERSION = 'v1.0.19';
+const VERSION = 'v1.0.20';
 const PRECACHE = `${CACHE_PREFIX}-precache-${VERSION}`;
 const RUNTIME  = `${CACHE_PREFIX}-runtime-${VERSION}`;
 


### PR DESCRIPTION
## Summary
- remove duplicação da definição de layout do bloco profile-core e mantém os botões de ação no fluxo normal
- garante que o único grupo de hero-actions permaneça dentro do núcleo do perfil sem posicionamento absoluto
- atualiza a versão do service worker para invalidar o cache anterior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db7fa0037883228003abfa1d78a31c