### PR TITLE
Fix profile hero layout and bump SW cache

### DIFF
--- a/perfil.html
+++ b/perfil.html
@@ -538,21 +538,6 @@
       box-shadow:0 10px 24px rgba(0,0,0,.35);
     }
 
-    /* Botões ao lado do nome (participam do fluxo) */
-    .profile-core .hero-actions {
-      position: static;
-      margin-left: auto;
-      display: flex;
-      flex-direction: column;
-      gap: 10px;
-    }
-
-    /* Quando o banner button estiver no grupo, não é absoluto */
-    .hero-actions #bannerEditBtn {
-      position: static !important;
-      inset: auto !important;
-    }
-
     /* (Já existente) Nome + badges alinham por baseline em telas maiores */
     @media (min-width: 720px) {
       .profile-info {
@@ -570,6 +555,25 @@
         margin-left: 0;
         justify-content: flex-start;
       }
+    }
+
+    /* Centraliza avatar + nome/pílulas + ações */
+    .profile-core{
+      display:flex;
+      align-items:center !important;
+      gap:16px;
+    }
+    /* Ações vão para a direita e viram coluna em telas pequenas (se quiser) */
+    .profile-core .hero-actions{
+      margin-left:auto;
+      display:flex;
+      flex-direction:column;
+      gap:10px;
+    }
+    /* Mata qualquer posicionamento absoluto legado do banner */
+    .profile-hero .hero-actions, .profile-hero .banner-btn{
+      position:static !important;
+      inset:auto !important;
     }
   </style>
 </head>

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,8 @@
 // sw.js
-// SW v1.0.20 — precache do shell + stale-while-revalidate para assets (mesmo-origin)
+// SW v1.0.21 — precache do shell + stale-while-revalidate para assets (mesmo-origin)
 
 const CACHE_PREFIX = 'lmu-cache';
-const VERSION = 'v1.0.20';
+const VERSION = 'v1.0.21';
 const PRECACHE = `${CACHE_PREFIX}-precache-${VERSION}`;
 const RUNTIME  = `${CACHE_PREFIX}-runtime-${VERSION}`;
 


### PR DESCRIPTION
## Summary
- nest the profile hero action buttons within the profile core block and remove the legacy positioning styles that conflicted with the layout
- append the new flexbox overrides at the end of the inline stylesheet so the avatar, info, and actions align correctly without absolute positioning
- bump the service worker cache version to trigger clients to pick up the refreshed layout immediately

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68db828481a48322a6bf774fd8a75584