### PR TITLE
Adjust profile flex wrapping behavior

### DIFF
--- a/perfil.html
+++ b/perfil.html
@@ -223,7 +223,7 @@
       gap:16px;
       padding:0 24px 24px;
       margin-top:0;
-      flex-wrap:wrap;
+      flex-wrap:nowrap;
     }
     .avatar{
       width:108px;
@@ -410,6 +410,7 @@
       .avatar{ width:92px; height:92px; border-radius:20px; }
     }
     @media (max-width: 720px){
+      .profile-core{ flex-wrap:wrap; }
       .profile-badges{ margin-left:0; justify-content:flex-start; width:100%; }
     }
     @media (max-width: 560px){


### PR DESCRIPTION
## Summary
- disable wrapping on the profile core container for wide layouts to keep the hero actions aligned with the avatar
- restore wrapping for screens up to 720px to maintain responsive stacking

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db8511e68c83229becef62018bb336