### PR TITLE
Fix profile-core padding symmetry

### DIFF
--- a/perfil.html
+++ b/perfil.html
@@ -553,7 +553,7 @@
       display:flex;
       align-items:center;
       gap:16px;
-      padding:0 24px 24px;
+      padding:16px 24px;
       margin-top:0;
       flex-wrap:wrap;
     }
@@ -574,14 +574,14 @@
 
     /* responsivo */
     @media (max-width:980px){
-      .profile-core{ padding:0 16px 20px; }
+      .profile-core{ padding:16px; }
     }
     @media (max-width:720px){
       .profile-core{
         flex-direction:column;
         align-items:flex-start;
         gap:16px;
-        padding:0 16px 24px;
+        padding:20px 16px;
       }
       .profile-core .hero-actions{
         width:100%;


### PR DESCRIPTION
## Summary
- align the base profile-core padding to use matching top and bottom values
- ensure the 980px breakpoint uses uniform padding on all sides
- adjust the 720px breakpoint to keep top and bottom spacing consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db8bfae4ac832288fabadcd925421c