### PR TITLE
Centralize card section titles

### DIFF
--- a/perfil.html
+++ b/perfil.html
@@ -601,6 +601,9 @@
     .dark-mode .achievement.unlocked{
       background: rgba(246, 196, 83, 0.22);    /* dourado suave no dark */
     }
+    .card > h2 {
+      text-align: center;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- center align card section headings on the profile page to improve visual presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db958d0eb8832299d952a36fc70301