### PR TITLE
Add light-mode borders to cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,6 +332,10 @@
       --fa-primary-color: var(--color-gold) !important;
       --fa-secondary-color: var(--color-gold) !important;
     }
+
+    body:not(.dark-mode) .subarea-card{
+      border:2px solid #000000;
+    }
   </style>
 </head>
 <body>

--- a/perfil.html
+++ b/perfil.html
@@ -604,6 +604,10 @@
     .card > h2 {
       text-align: center;
     }
+
+    body:not(.dark-mode) .card{
+      border:2px solid #000000;
+    }
   </style>
 </head>
 <body>

--- a/progresso.html
+++ b/progresso.html
@@ -408,6 +408,14 @@
         --text-muted:  hsl(215 20% 72%);
       }
     }
+
+    body:not(.dark-mode) .card{
+      border:2px solid #000000;
+    }
+
+    body:not(.dark-mode) .subjects-grid article.subject-tile{
+      border:2px solid #000000;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add a dedicated light-mode rule so home knowledge area cards display a 2px black border
- ensure progress page section cards and subject tiles receive matching light-mode borders
- update profile cards to share the same light-mode border treatment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db98b0b0e48322be3bd313bcab8d05