### PR TITLE
Adjust dashboard alignment and theme card styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,21 +334,27 @@
     }
 
     body:not(.dark-mode) .subarea-card{
-      border:2px solid #000000;
-    }
-    .subarea-card{
-      border:1px solid var(--border, var(--color-border));
-      background:var(--card, #fff);
-      border-radius:var(--radius, 6px);
-    }
-
-    body:not(.dark-mode) .subarea-card{
-      border:1px solid var(--border, var(--color-border));
+      border:2px solid #000;
+      background:#fff;
     }
 
     body.dark-mode .subarea-card{
-      border:1px solid var(--border-dark-contrast, var(--color-border-dark-contrast));
-      background:var(--card-dark, var(--color-card-bg-dark));
+      border:1px solid var(--color-border-dark-contrast);
+      background:var(--color-card-bg-dark);
+    }
+
+    body:not(.dark-mode) .knowledge-area > h3{
+      background:#fff;
+      border:2px solid #000;
+      border-radius:8px;
+      padding:8px 12px;
+    }
+
+    body.dark-mode .knowledge-area > h3{
+      background:var(--color-card-bg-dark);
+      border:1px solid var(--color-border-dark-contrast);
+      border-radius:8px;
+      padding:8px 12px;
     }
   </style>
 </head>

--- a/perfil.html
+++ b/perfil.html
@@ -601,19 +601,22 @@
     .dark-mode .achievement.unlocked{
       background: rgba(246, 196, 83, 0.22);    /* dourado suave no dark */
     }
-    .card > h2 { 
+    .card > h2 {
       text-align: left;
     }
 
     body:not(.dark-mode) .card{
       border:2px solid #000000;
     }
-    div#xpChartContainer{ text-align:center; }
 
-    h2#achievementsTitle,
-    h2#progressTitle,
-    h2#tipsTitle{
-      text-align:center;
+    #xpChartContainer {
+      text-align: center;
+    }
+
+    #xpDashTitle,
+    #activityTitle,
+    #achievementsTitle {
+      text-align: center;
     }
   </style>
 </head>

--- a/progresso.html
+++ b/progresso.html
@@ -410,12 +410,9 @@
     }
 
     body:not(.dark-mode) .card{
-      border:2px solid #000000;
+      border:2px solid #000;
     }
 
-    body:not(.dark-mode) .subjects-grid article.subject-tile{
-      border:2px solid #000000;
-    }
     h3#quests-h,
     h3#mastery-h,
     h3#badges-h{
@@ -428,13 +425,13 @@
       border-radius:var(--radius);
     }
 
-    body:not(.dark-mode) .subjects-grid article.subject-tile{
-      border:1px solid var(--border);
-    }
-
     body.dark-mode .subject-tile{
       border-color:var(--border-dark-contrast);
       background:var(--card-dark);
+    }
+
+    body:not(.dark-mode) .subjects-grid article.subject-tile{
+      border:2px solid #000;
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- center the XP dashboard graph container and section headings on the profile page
- ensure lateral column headings and light theme subject tiles are centered and thickened on the progress page
- add light/dark theme-specific styling for subarea cards and knowledge area headers on the index page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dba2936d48832292d1762be8791dab