### PR TITLE
Refine heading borders for knowledge area sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,11 +213,31 @@
     .main h2{ margin-bottom:15px; font-weight:700; font-size:22px; }
 
     .knowledge-area{ margin-top:30px; }
-    .knowledge-area h3{
-      font-size:18px; margin-bottom:10px; border-left:4px solid var(--color-primary);
-      padding-left:8px; font-weight:700; color:var(--color-primary);
+    .knowledge-area > h3{
+      display:inline-flex;
+      align-items:center;
+      font-size:18px;
+      margin:0 0 10px;
+      font-weight:700;
+      color:var(--color-primary);
+      padding:8px 12px;
+      border-radius:var(--radius);
+      border:2px solid transparent;
+      background:transparent;
     }
-    body.dark-mode .knowledge-area > h3{ color:var(--color-gold); border-left-color:var(--color-gold); }
+    body.dark-mode .knowledge-area > h3{ color:var(--color-gold); }
+
+    h2#areas{
+      display:inline-flex;
+      align-items:center;
+      margin:0 0 15px;
+      padding:12px 16px;
+      font-weight:700;
+      font-size:22px;
+      border-radius:var(--radius);
+      border:2px solid transparent;
+      background:transparent;
+    }
 
     .subarea-grid{ display:grid; grid-template-columns: repeat(auto-fill, minmax(270px, 1fr)); gap:20px; margin-bottom:40px; }
     .subarea-card{
@@ -343,18 +363,16 @@
       background:var(--color-card-bg-dark);
     }
 
-    body:not(.dark-mode) .knowledge-area > h3{
+    body:not(.dark-mode) .knowledge-area > h3,
+    body:not(.dark-mode) h2#areas{
       background:#fff;
-      border:2px solid #000;
-      border-radius:8px;
-      padding:8px 12px;
+      border-color:#000;
     }
 
-    body.dark-mode .knowledge-area > h3{
+    body.dark-mode .knowledge-area > h3,
+    body.dark-mode h2#areas{
       background:var(--color-card-bg-dark);
-      border:1px solid var(--color-border-dark-contrast);
-      border-radius:8px;
-      padding:8px 12px;
+      border-color:var(--color-border-dark-contrast);
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- restyled knowledge area section headings to be compact inline elements with full borders matching the card aesthetic
- applied the same bordered treatment to the "Áreas do Conhecimento" heading with appropriate light and dark mode colors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dba5a71d388322bdf63a9be4199765