### PR TITLE
Remove knowledge areas heading and adjust section spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,6 +213,7 @@
     .main h2{ margin-bottom:15px; font-weight:700; font-size:22px; }
 
     .knowledge-area{ margin-top:30px; }
+    .knowledge-area:first-of-type{ margin-top:10px; }
     .knowledge-area > h3{
       display:inline-flex;
       align-items:center;
@@ -226,18 +227,6 @@
       background:transparent;
     }
     body.dark-mode .knowledge-area > h3{ color:var(--color-gold); }
-
-    h2#areas{
-      display:inline-flex;
-      align-items:center;
-      margin:0 0 15px;
-      padding:12px 16px;
-      font-weight:700;
-      font-size:22px;
-      border-radius:var(--radius);
-      border:2px solid transparent;
-      background:transparent;
-    }
 
     .subarea-grid{ display:grid; grid-template-columns: repeat(auto-fill, minmax(270px, 1fr)); gap:20px; margin-bottom:40px; }
     .subarea-card{
@@ -363,14 +352,12 @@
       background:var(--color-card-bg-dark);
     }
 
-    body:not(.dark-mode) .knowledge-area > h3,
-    body:not(.dark-mode) h2#areas{
+    body:not(.dark-mode) .knowledge-area > h3{
       background:#fff;
       border-color:#000;
     }
 
-    body.dark-mode .knowledge-area > h3,
-    body.dark-mode h2#areas{
+    body.dark-mode .knowledge-area > h3{
       background:var(--color-card-bg-dark);
       border-color:var(--color-border-dark-contrast);
     }
@@ -464,10 +451,8 @@
     </aside>
 
     <main class="main" id="mainContent" role="main">
-      <h2 id="areas">Áreas do Conhecimento</h2>
-
       <!-- Exatas -->
-      <section class="knowledge-area" aria-labelledby="exatas-title">
+      <section class="knowledge-area" id="areas" aria-labelledby="exatas-title">
         <h3 id="exatas-title">Ciências Exatas e da Natureza</h3>
         <div class="subarea-grid">
           <div class="subarea-card">


### PR DESCRIPTION
## Summary
- remove the Áreas do Conhecimento heading and its decorative styles
- move the section anchor to the first knowledge area and tighten the initial spacing

## Testing
- no automated tests were run (not required for this change)

------
https://chatgpt.com/codex/tasks/task_e_68dba98064fc832284a56824e85e5129